### PR TITLE
Relative import for python3 compatibility

### DIFF
--- a/pysbf/__init__.py
+++ b/pysbf/__init__.py
@@ -1,1 +1,1 @@
-from sbf import load
+from .sbf import load


### PR DESCRIPTION
With this simple change I was able to import the module correctly with python3. The examples run fine too.

I guess it will fix #2 too.